### PR TITLE
fix repo url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,8 @@ site_url: https://teamtomo.org
 site_author: teamtomo
 site_description: >-
   Modular Python packages the cryo-ET community can depend on.
-repo_name: teamtomo/teamtomo.org
-repo_url: https://github.com/teamtomo/teamtomo.org
+repo_name: teamtomo/teamtomo.github.io
+repo_url: https://github.com/teamtomo/teamtomo.github.io
 edit_uri: edit/main/src
 docs_dir: src
 copyright: Copyright &copy; 2024 - 2025 teamtomo


### PR DESCRIPTION
I noticed the link to the repo on teamtomo.org was broken. I believe this should fix it.

The contributors page is also broken. There is no `teams.md` in the `site` folder. Perhaps the contributors page is meant to be `team_template.md` in `dynamic`?